### PR TITLE
Add feature to configure datetime and date format

### DIFF
--- a/application/config/config.php.sample
+++ b/application/config/config.php.sample
@@ -12,15 +12,19 @@ $config['jobs_per_page'] = 25;
 // Translations
 $config['language'] = 'en_US';
 
-// en_US -> English - maintened by Davide Franco (bacula-dev@dflc.ch)
-// es_ES -> Spanish - Mantained by Juan Luis Franc�s Jim�nez
-// it_IT -> Italian - Mantained by Gian Domenico Messina (gianni.messina AT c-ict.it)
-// fr_FR -> French - Mantained by Morgan LEFIEUX (comete AT daknet.org)
-// de_DE -> German - Mantained by Florian Heigl
-// sv_SV -> Swedish - Maintened by Daniel Nylander (po@danielnylander.se)
-// pt_BR -> Portuguese Brazil - Last updated by J. Ritter (condector@gmail.com) 
-// nl_NL -> Dutch - last updated by Dion van Adrichem
-// ja_JP -> Japanese - Last updated by Ken Sawada (ksawa0126@gmail.com)
+// en_US -> English 
+// es_ES -> Spanish 
+// it_IT -> Italian
+// fr_FR -> French
+// de_DE -> German
+// sv_SV -> Swedish
+// pt_BR -> Portuguese Brazil
+// nl_NL -> Dutch 
+// ja_JP -> Japanese
+// no_NO -> Norvegian
+// ru_RU -> Russian
+// sv_SV -> Swedish
+// zh_CN -> Chinese
 
 // Database connection parameters
 // Copy/paste and adjust parameters according to your configuration

--- a/application/config/config.php.sample
+++ b/application/config/config.php.sample
@@ -9,6 +9,15 @@ $config['hide_empty_pools'] = false;
 // Jobs per page (Jobs report page)
 $config['jobs_per_page'] = 25;
 
+// Jobs per page (Jobs report page)
+$config['jobs_per_page'] = 25;
+
+//Format datetime  (Default: Y-m-d H:i:s)
+//$config['datetime_format'] = '';
+
+//Format date  (Default: Y-m-d)
+//$config['date_format'] = '';
+
 // Translations
 $config['language'] = 'en_US';
 

--- a/backupjob-report.php
+++ b/backupjob-report.php
@@ -40,8 +40,8 @@ try {
     }
     
     // Generate Backup Job report period string
-    $backupjob_period = "From " . date("Y-m-d", (NOW - WEEK)) . " to " . date("Y-m-d", NOW);
-    
+    $backupjob_period = "From " . CUtils::format_Date(date("Y-m-d", (NOW - WEEK)), $config['date_format']) . " to " . CUtils::format_Date(date("Y-m-d", NOW), $config['date_format']);
+
     // Stored Bytes on the defined period
     $backupjob_bytes = Jobs_Model::getStoredBytes($dbSql->db_link, array(LAST_WEEK, NOW), $backupjob_name);
     $backupjob_bytes = CUtils::Get_Human_Size($backupjob_bytes);
@@ -118,6 +118,8 @@ try {
         // Job speed
         $start         = $job['starttime'];
         $end           = $job['endtime'];
+        $job['starttime']  = CUtils::format_DateTime($start, $config['datetime_format']);
+        $job['endtime']    = CUtils::format_DateTime($end, $config['datetime_format']);
         $seconds 	   = DateTimeUtil::get_ElaspedSeconds($end, $start);
 
         if ($seconds !== false && $seconds > 0) {

--- a/client-report.php
+++ b/client-report.php
@@ -73,7 +73,7 @@ try {
             $job['level']     = $job_levels[$job['level']];
             $job['jobfiles']     = CUtils::format_Number($job['jobfiles']);
             $job['jobbytes']     = CUtils::Get_Human_Size($job['jobbytes']);
-          
+            $job['endtime'] = CUtils::format_DateTime($job['endtime'], $config['datetime_format']);
             $backup_jobs[] = $job;
         }
     }

--- a/core/app/cview.class.php
+++ b/core/app/cview.class.php
@@ -27,7 +27,7 @@ class CView extends Smarty
     private function init()
     {
         // Set to true to force template generation if a template has changed
-        $this->compile_check = false;
+        $this->compile_check = $config['compile_check'];
 
         // Template caching
         $this->cache_dir = VIEW_CACHE_DIR;

--- a/core/app/cview.class.php
+++ b/core/app/cview.class.php
@@ -27,7 +27,7 @@ class CView extends Smarty
     private function init()
     {
         // Set to true to force template generation if a template has changed
-        $this->compile_check = $config['compile_check'];
+        $this->compile_check = false;
 
         // Template caching
         $this->cache_dir = VIEW_CACHE_DIR;

--- a/core/utils/cutils.class.php
+++ b/core/utils/cutils.class.php
@@ -68,4 +68,38 @@ class CUtils
         // Return formated number
         return number_format($number, $decimal, $locale['decimal_point'], $locale['thousands_sep']);
     }
+
+    // ==================================================================================
+    // Function: 	format_Date()
+    // Parameters:	$date
+    //				$format (optional, default = null)
+    // Return:		formated date
+    // ==================================================================================
+    public static function format_Date($date, $format = null)
+    {
+        // Return formated date
+        if($format == null) {
+           return date('Y-m-d', strtotime($date));
+        } else {
+             return date($format, strtotime($date) );
+        }
+    }
+
+    // ==================================================================================
+    // Function: 	format_DateTime()
+    // Parameters:	$date
+    //				$format (optional, default = null)
+    // Return:		formated date
+    // ==================================================================================
+    public static function format_DateTime($date, $format = null)
+    {
+        // Return formated date
+        if($format == null) {
+           return date('Y-m-d H:i:s', strtotime($date));
+        } else {
+             return date($format, strtotime($date) );
+        }
+    }
+//$this->escape(date($this->datetime_format,strtotime($line['last_login'])));?
+
 }

--- a/index.php
+++ b/index.php
@@ -258,6 +258,8 @@ try {
     $result     = CDBUtils::runQuery(CDBQuery::get_Select($statment), $dbSql->db_link);
 
     foreach ($result as $volume) {
+        $lastwritten = $volume['lastwritten'];
+        $volume['lastwritten'] = CUtils::format_DateTime($lastwritten, $config['date_format']);
         $last_volumes[] = $volume;
     }
 

--- a/index.php
+++ b/index.php
@@ -258,8 +258,7 @@ try {
     $result     = CDBUtils::runQuery(CDBQuery::get_Select($statment), $dbSql->db_link);
 
     foreach ($result as $volume) {
-        $lastwritten = $volume['lastwritten'];
-        $volume['lastwritten'] = CUtils::format_DateTime($lastwritten, $config['date_format']);
+        $volume['lastwritten'] = CUtils::format_DateTime($volume['lastwritten'], $config['date_format']);
         $last_volumes[] = $volume;
     }
 

--- a/joblogs.php
+++ b/joblogs.php
@@ -37,6 +37,8 @@ try {
     // Processing result
     foreach ($result->fetchAll() as $log) {
         $log['logtext'] = nl2br($log['logtext']);
+        $time = $log['time'];
+        $log['time'] = CUtils::format_DateTime($time, $config['datetime_format']);
         $joblogs[]         = $log;
     }
 

--- a/joblogs.php
+++ b/joblogs.php
@@ -37,8 +37,7 @@ try {
     // Processing result
     foreach ($result->fetchAll() as $log) {
         $log['logtext'] = nl2br($log['logtext']);
-        $time = $log['time'];
-        $log['time'] = CUtils::format_DateTime($time, $config['datetime_format']);
+        $log['time'] = CUtils::format_DateTime($log['time'], $config['datetime_format']);
         $joblogs[]         = $log;
     }
 

--- a/jobs.php
+++ b/jobs.php
@@ -262,6 +262,8 @@
         // Job start time, end time and elapsed time
         $start_time = $job['starttime'];
         $end_time   = $job['endtime'];
+        $job['starttime'] = CUtils::format_DateTime($start_time, $config['datetime_format']);
+        $job['endtime']   = CUtils::format_DateTime($start_time, $config['datetime_format']);
       
         if ($start_time == '0000-00-00 00:00:00' or is_null($start_time) or $start_time == 0) {
             $job['starttime'] = 'n/a';

--- a/jobs.php
+++ b/jobs.php
@@ -182,9 +182,9 @@
 
   // Order result by
     $result_order = array(
-      'SchedTime' => 'Job Scheduled Time',
-    'starttime' => 'Job Start Date',
-    'endtime'   => 'Job End Date',
+      'schedtime' => 'Job Scheduled Time',
+      'starttime' => 'Job Start Date',
+      'endtime'   => 'Job End Date',
       'jobid'     => 'Job Id',
       'Job.Name'  => 'Job Name',
       'jobbytes'  => 'Job Bytes',
@@ -266,14 +266,15 @@
         } // end switch
 
         // Sched time
-        $sched_time = $job['SchedTime'];
+        $sched_time = $job['schedtime'];
 
         // Job start time, end time and elapsed time
         $start_time = $job['starttime'];
         $end_time   = $job['endtime'];
 
-        $job['starttime'] = CUtils::format_DateTime($start_time, $config['datetime_format']);
-        $job['endtime']   = CUtils::format_DateTime($start_time, $config['datetime_format']);
+        $job['starttime']   = CUtils::format_DateTime($start_time, $config['datetime_format']);
+        $job['endtime']     = CUtils::format_DateTime($start_time, $config['datetime_format']);
+        $job['schedtime']   = CUtils::format_DateTime($sched_time, $config['datetime_format']);
       
         if ($start_time == '0000-00-00 00:00:00' or is_null($start_time) or $start_time == 0) {
             $job['starttime'] = 'n/a';

--- a/pools.php
+++ b/pools.php
@@ -23,8 +23,18 @@
  $view = new CView();
  $dbSql = new Bweb($view);
 
+ $result = $dbSql->GetVolumeList();
+ // Looping over the array to change the 'expire' and 'lastwritten' fields with the date/time format
+ foreach ($result as $key1 => $value1) {
+    foreach ($result[$key1]['volumes'] as $key2 => $value2) {
+       $expire      =  $result[$key1]['volumes'][$key2]['expire'];
+       $lastwritten =  $result[$key1]['volumes'][$key2]['lastwritten'];
+       $result[$key1]['volumes'][$key2]['expire'] = CUtils::format_DateTime($expire, $config['date_format']);;
+       $result[$key1]['volumes'][$key2]['lastwritten'] = CUtils::format_DateTime($lastwritten, $config['datetime_format']);;
+    }
+ }
  // Get volumes list (pools.tpl)
- $view->assign('pools', $dbSql->GetVolumeList());
+ $view->assign('pools', $result);
 
  // Set page name
  $current_page = 'Pools and volumes report';


### PR DESCRIPTION
Include feature to configure datetime and date format. 
I Brazil is used 'd/m/Y' and not 'Y-m-d'. 
Now is possible to configure this option in config.php.sample.

Best regards
Wanderlei