### PR TITLE
[WIP] v11 release has made some changes to the DB structure which breaks job/file queries

### DIFF
--- a/application/models/jobfiles.model.php
+++ b/application/models/jobfiles.model.php
@@ -10,28 +10,68 @@
 
 class JobFiles_Model extends CModel
 {
+
+    protected $dbVersionId;
+
+    protected function getDbVersionId(){
+        if($this->dbVersionId){
+            return $this->dbVersionId;
+        }
+        $sqlQuery = CDBQuery::get_Select( array('table' => 'Version',
+            'fields' => array('VersionId'),
+            'limit' => array( 'count' => 1, 'offset' => 0)
+        ), $this->driver );
+        $result = $this->run_query($sqlQuery);
+        $dbVersionId = $result->fetchColumn();
+        if($dbVersionId){
+            $this->dbVersionId = $dbVersionId;
+            return $this->dbVersionId;
+        }
+    }
+
     public function getJobFiles($jobId, $limit, $offset, $filename = '')
     {
         $used_types = array();
 
-        $fields = array('Job.Name', 'Job.JobStatus', 'File.FileIndex', 'Path.Path', 'Filename.Name');
-        $where = array("File.JobId = $jobId");
+        if($this->getDbVersionId()<1016){
 
-        if (!empty($filename)) {
-            $where[] = "(Filename.Name LIKE '%$filename%' OR Path.Path LIKE '%$filename%' OR concat(Path.Path, '', Filename.Name) = '$filename')";
+            $fields = array('Job.Name', 'Job.JobStatus', 'File.FileIndex', 'Path.Path', 'Filename.Name');
+            $where = array("File.JobId = $jobId");
+              if (! empty($filename)) {
+                  $where[] = "(Filename.Name LIKE '%$filename%' OR Path.Path LIKE '%$filename%' OR concat(Path.Path, '', Filename.Name) = '$filename')";
+              }
+
+            $orderby = 'File.FileIndex ASC';
+            $sqlQuery = CDBQuery::get_Select(array('table' => 'File',
+                'fields' => $fields,
+                'join' =>   array(  array('table' => 'Path', 'condition' => 'Path.PathId = File.PathId'),
+                                    array('table' => 'Filename', 'condition' => 'File.FilenameId = Filename.FilenameId'),
+                                      array('table' => 'Job', 'condition' => 'Job.JobId = File.JobId') ),
+                  'where' => $where,
+                  'orderby' => $orderby,
+                  'limit' => array( 'count' => $limit, 'offset' => $offset*$limit),
+                  'offset' => ($offset*$limit)
+              ), $this->driver);
+
+        } else {
+            $fields = array('Job.Name', 'Job.JobStatus', 'File.FileIndex', 'Path.Path', 'File.Filename');
+            $where = array("File.JobId = $jobId");
+
+            if( !empty($filename) ) {
+              $where[] = "(File.Filename LIKE '%$filename%' OR Path.Path LIKE '%$filename%' OR concat(Path.Path, '', File.Filename) = '$filename')";
+            }
+
+            $orderby = 'File.FileIndex ASC';
+            $sqlQuery = CDBQuery::get_Select( array('table' => 'File',
+                'fields' => $fields,
+                'join' =>   array(  array('table' => 'Path', 'condition' => 'Path.PathId = File.PathId'),
+                                    array('table' => 'Job', 'condition' => 'Job.JobId = File.JobId') ),
+                'where' => $where,
+                'orderby' => $orderby,
+                'limit' => array( 'count' => $limit, 'offset' => $offset*$limit),
+                'offset' => ($offset*$limit)
+            ), $this->driver );
         }
-        
-        $orderby = 'File.FileIndex ASC';
-        $sqlQuery = CDBQuery::get_Select(array('table' => 'File',
-            'fields' => $fields,
-            'join' =>   array(  array('table' => 'Path', 'condition' => 'Path.PathId = File.PathId'),
-                                array('table' => 'Filename', 'condition' => 'File.FilenameId = Filename.FilenameId'),
-                                array('table' => 'Job', 'condition' => 'Job.JobId = File.JobId') ),
-            'where' => $where,
-            'orderby' => $orderby,
-            'limit' => array( 'count' => $limit, 'offset' => $offset*$limit),
-            'offset' => ($offset*$limit)
-         ), $this->driver);
 
         $result = $this->run_query($sqlQuery);
 
@@ -39,20 +79,35 @@ class JobFiles_Model extends CModel
 
         return $used_types;
     }
-    
+
     public function countJobFiles($jobId, $filename = '')
     {
         $used_types = array();
-        $sql_query = "SELECT COUNT(*) as count
-			FROM File, Path, Filename, Job 
-			WHERE File.JobId = $jobId 
-			AND  Path.PathId = File.PathId 
-			AND  Filename.FilenameId = File.FilenameId 
-            AND  Job.JobId = File.JobId ";
 
-        // Filter by filename if requested
-        if (!empty($filename)) {
-            $sql_query .= "AND (Filename.Name LIKE '%$filename%' OR Path.Path LIKE '%$filename%' OR concat(Path.Path, '', Filename.Name) = '$filename') ";
+        if($this->getDbVersionId()<1016){
+
+            $sql_query = "SELECT COUNT(*) as count
+    			FROM File, Path, Filename, Job
+    			WHERE File.JobId = $jobId
+    			AND  Path.PathId = File.PathId
+    			AND  Filename.FilenameId = File.FilenameId
+                AND  Job.JobId = File.JobId ";
+
+            // Filter by filename if requested
+            if (!empty($filename)) {
+                $sql_query .= "AND (Filename.Name LIKE '%$filename%' OR Path.Path LIKE '%$filename%' OR concat(Path.Path, '', Filename.Name) = '$filename') ";
+            }
+        } else {
+          $sql_query = "SELECT COUNT(*) as count
+                FROM File, Path, Job
+                WHERE File.JobId = $jobId
+                AND  Path.PathId = File.PathId
+                      AND  Job.JobId = File.JobId ";
+
+            // Filter by filename if requested
+            if( !empty($filename)) {
+              $sql_query .= "AND (File.Filename LIKE '%$filename%' OR Path.Path LIKE '%$filename%' OR concat(Path.Path, '', File.Filename) = '$filename') ";
+            }
         }
 
         $sql_query .= ";";
@@ -63,12 +118,12 @@ class JobFiles_Model extends CModel
 
         return $used_types[0]['count'];
     }
-    
+
     public function getJobNameAndJobStatusByJobId($jobId)
     {
         $used_types = array();
         $sql_query = "SELECT distinct Job.Name, Job.JobStatus
-			FROM Job 
+			FROM Job
 			WHERE Job.JobId = $jobId;";
         $result = $this->run_query($sql_query);
 
@@ -110,7 +165,7 @@ class JobFiles_Model extends CModel
                     break;
             }
         }
-        
+
         return $used_types;
     }
 }


### PR DESCRIPTION

>  [New Features in 11.0.0](https://www.bacula.org/11.0.x-manuals/en/main/New_Features_in_11_0_0.html)
> There is a new Bacula database format (schema) in this version of Bacula **that eliminates the FileName table by** placing the Filename into the File record of the File table. This substantiallly improves performance, particularly for large databases. 



https://www.bacula.org/git/cgit.cgi/bacula/tree/bacula/src/cats/update_mysql_tables.in#n257