### PR TITLE
fix: fix catalog drop-down visible to anyone

### DIFF
--- a/application/views/templates/partials/navbar.tpl
+++ b/application/views/templates/partials/navbar.tpl
@@ -31,6 +31,7 @@
             {/if}
 
             <ul class="nav navbar-nav navbar-right">
+                {if $user_authenticated eq 'yes' or $enable_users_auth eq false }
                         <!-- Catalog selector -->
                         <li class="dropdown">
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i
@@ -51,6 +52,7 @@
                             </ul>
                         </li>
                   <!-- end Catalog selector -->
+                {/if}
                   <!-- Authenticated user options -->
                 {if isset($user_authenticated) }
                     {if $enable_users_auth eq 'true' and $user_authenticated eq 'yes' }


### PR DESCRIPTION
Fix the Bacula catalog drop-down list visible to unauthenticated user(s) (fromlogin page) by updating navbar template code.

Fix: #156