### PR TITLE
add MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Bacula-Web can be installed using Composer, [Docker](docker/README.md) or from s
 ### Using Composer
 
 - Required [PHP](https://www.php.net/) version is >= 8.0 
-- Make sure PHP CLI installed and extensions [SQlite3](https://www.php.net/manual/en/book.sqlite3.php), [Gettext](https://www.php.net/manual/en/book.gettext.php), [Session](https://www.php.net/manual/en/refs.basic.session.php), [PDO](https://www.php.net/manual/en/book.pdo.php), [MySQL](https://www.php.net/manual/en/set.mysqlinfo.php), [postgreSQL](https://www.php.net/manual/en/book.pgsql.php), [Json](https://www.php.net/manual/en/book.json.php) and [Posix](https://www.php.net/manual/en/book.posix.php) are installed and enabled.
+- Make sure PHP CLI installed and extensions [SQlite3](https://www.php.net/manual/en/book.sqlite3.php), [Gettext](https://www.php.net/manual/en/book.gettext.php), [Session](https://www.php.net/manual/en/refs.basic.session.php), [PDO](https://www.php.net/manual/en/book.pdo.php), [MariaDB and MySQL](https://www.php.net/manual/en/set.mysqlinfo.php), [postgreSQL](https://www.php.net/manual/en/book.pgsql.php), [Json](https://www.php.net/manual/en/book.json.php) and [Posix](https://www.php.net/manual/en/book.posix.php) are installed and enabled.
 - Install [Composer](https://getcomposer.org/doc/00-intro.md)
 - Install Bacula-Web from [Packagist](https://packagist.org/packages/bacula-web/bacula-web)
   ``` shell


### PR DESCRIPTION
Suggesting MariaDB to be added to README as discussed in [discussions/225](https://github.com/bacula-web/bacula-web/discussions/225). MariaDB is also now mentioned as compatible on [PHP MySQL Driver and Plugins](https://www.php.net/manual/en/set.mysqlinfo.php) that the README links to - as of [/php/doc-en/pull/3639](https://github.com/php/doc-en/pull/3639). 