### PR TITLE
chore: fix website deployment

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:lts AS builder
+
+ENV FORCE_COLOR=0
+
+RUN apt install -y git
+
+RUN corepack enable
+
+WORKDIR /src
+
+COPY . .
+
+RUN npm ci
+
+RUN npm run build
+
+EXPOSE 80

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -57,8 +57,8 @@ const config = {
                         type: ['rss', 'atom'],
                         xslt: true,
                     },
-                    showLastUpdateTime: true,
-                    showLastUpdateAuthor: true,
+                    showLastUpdateTime: false,
+                    showLastUpdateAuthor: false,
                     // Please change this to your repo.
                     // Remove this to remove the "edit this page" links.
                     /*


### PR DESCRIPTION
Use a Dockerfile to build and deploy the website and documentation.

Temporarely Disable last updated and authors due to an issue in Docusaurus.

Based on the instructions from https://docusaurus.community/knowledge/deployment/docker/.